### PR TITLE
Add empty states and switch to Phosphor icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
+        "@phosphor-icons/vue": "^2.2.1",
         "@tailwindcss/vite": "^4.1.13",
         "js-md5": "^0.8.3",
-        "oh-vue-icons": "^1.0.0-rc3",
         "tailwindcss": "^4.1.13",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",
@@ -1238,6 +1238,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@phosphor-icons/vue": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/vue/-/vue-2.2.1.tgz",
+      "integrity": "sha512-3RNg1utc2Z5RwPKWFkW3eXI/0BfQAwXgtFxPUPeSzi55jGYUq16b+UqcgbKLazWFlwg5R92OCLKjDiJjeiJcnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "vue": ">=3.2.39"
       }
     },
     "node_modules/@pkgr/core": {
@@ -3281,9 +3293,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3641,9 +3653,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3696,9 +3708,9 @@
       }
     },
     "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.1.2"
@@ -3713,21 +3725,6 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
@@ -3819,50 +3816,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
-    "node_modules/oh-vue-icons": {
-      "version": "1.0.0-rc3",
-      "resolved": "https://registry.npmjs.org/oh-vue-icons/-/oh-vue-icons-1.0.0-rc3.tgz",
-      "integrity": "sha512-+k2YC6piK7sEZnwbkQF3UokFPMmgqpiLP6f/H0ovQFLl20QA5V4U8EcI6EclD2Lt5NMQ3k6ilLGo8XyXqdVSvg==",
-      "license": "MIT",
-      "dependencies": {
-        "vue-demi": "^0.12.5"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^2.0.0 || >=3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/oh-vue-icons/node_modules/vue-demi": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
-      "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "vue-demi-fix": "bin/vue-demi-fix.js",
-        "vue-demi-switch": "bin/vue-demi-switch.js"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      },
-      "peerDependencies": {
-        "@vue/composition-api": "^1.0.0-rc.1",
-        "vue": "^3.0.0-0 || ^2.6.0"
-      },
-      "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        }
       }
     },
     "node_modules/open": {
@@ -4385,16 +4338,15 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "license": "ISC",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
         "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
+        "minizlib": "^3.1.0",
         "yallist": "^5.0.0"
       },
       "engines": {
@@ -4541,9 +4493,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
-      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@mozilla/readability": "^0.6.0",
+    "@phosphor-icons/vue": "^2.2.1",
     "@tailwindcss/vite": "^4.1.13",
     "js-md5": "^0.8.3",
-    "oh-vue-icons": "^1.0.0-rc3",
     "tailwindcss": "^4.1.13",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",

--- a/src/components/EmptyFeed.vue
+++ b/src/components/EmptyFeed.vue
@@ -1,0 +1,11 @@
+<template>
+  <div class="flex flex-col items-center justify-center py-16 text-center bg-surface-container rounded-lg">
+    <PhPlant :size="48" weight="duotone" class="text-gray-400 mb-4" />
+    <h2 class="text-2xl font-semibold text-gray-300 mb-2">No posts yet</h2>
+    <p class="text-gray-400">New articles will appear here as the feed updates.</p>
+  </div>
+</template>
+
+<script setup>
+import { PhPlant } from '@phosphor-icons/vue'
+</script>

--- a/src/components/EmptyPromptKey.vue
+++ b/src/components/EmptyPromptKey.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="flex flex-col items-center justify-center p-16 text-center bg-surface-container rounded-lg">
+    <PhKey :size="48" weight="duotone" class="text-gray-400 mb-4" />
+    <h2 class="text-2xl font-semibold text-gray-300 mb-2">No API key configured</h2>
+    <p class="text-gray-400 mb-2">
+      Set the <code class="bg-surface-container px-2 py-1 rounded text-sm">CLAUDE_API_KEY</code> environment variable to enable prompt features.
+    </p>
+  </div>
+</template>
+
+<script setup>
+import { PhKey } from '@phosphor-icons/vue'
+</script>

--- a/src/components/EmptySubscriptions.vue
+++ b/src/components/EmptySubscriptions.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="flex flex-col items-center justify-center py-16 text-center bg-surface-container rounded-lg">
+    <PhPlant :size="48" weight="duotone" class="text-gray-400 mb-4" />
+    <h2 class="text-2xl font-semibold text-gray-300 mb-2">No subscriptions yet</h2>
+    <p class="text-gray-400 mb-6">Get started by adding your first feed.</p>
+    <RouterLink to="/subscriptions/new">
+      <StyledButton label="Add a Subscription" />
+    </RouterLink>
+  </div>
+</template>
+
+<script setup>
+import { RouterLink } from 'vue-router'
+import { PhPlant } from '@phosphor-icons/vue'
+import StyledButton from '@/components/StyledButton.vue'
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -4,13 +4,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router from './router'
 
-import { OhVueIcon, addIcons } from "oh-vue-icons";
-import { BiGrid1X2Fill } from "oh-vue-icons/icons";
-
-addIcons(BiGrid1X2Fill)
-
 const app = createApp(App)
 
 app.use(router)
-app.component("v-icon", OhVueIcon);
 app.mount('#app')

--- a/src/views/PromptView.vue
+++ b/src/views/PromptView.vue
@@ -2,78 +2,82 @@
   <div class="max-w-4xl">
     <h1 class="text-5xl font-bold mb-6">Curation Prompt</h1>
 
+    <EmptyPromptKey v-if="viewer?.has_prompt_key === false" />
+
     <!-- Instructions section (formerly ConsentView) -->
-    <div class="mb-8 p-6 bg-surface-container rounded-lg">
-      <h2 class="text-xl font-semibold mb-4">How AI Filtering Works</h2>
-      <p class="mb-4">
-        Seymour uses Claude AI to intelligently filter your RSS feeds based on your preferences.
-        You provide custom prompts that act as filtering criteria, and Claude decides which posts to show or hide.
-        This creates a personalized, curated timeline that matches your interests.
-      </p>
-      <p class="mb-4">
-        To curate your feed, simply describe what you'd like to see...or not see.
-        For example:
-      </p>
-      <div class="space-y-3">
-        <div class="bg-surface p-3 rounded border-l-4 border-primary">
-          <code class="text-sm">"Show me recipes for healthy meals, but not ones that include garlic."</code>
-        </div>
-      </div>
-      <p class="mt-4 text-sm text-gray-600">
-        Your feed is in your control! As with any prompt, being incredibly descriptive or providing examples
-        will yield more favorable results.
-      </p>
-    </div>
-
-    <!-- Form section (formerly EditPromptView) -->
-    <form @submit.prevent="handleSubmit" class="mb-6">
-      <label for="prompt" class="block text-lg font-medium mb-3">
-        Your Filtering Prompt
-      </label>
-      <textarea id="prompt" v-model="promptText"
-        class="w-full h-64 px-4 py-3 border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-primary focus:border-primary"
-        placeholder="Enter your filtering prompt here... For example: 'Show me posts about technology, programming, and AI, but hide posts about celebrity gossip or sports.'" />
-
-      <!-- Character count and validation feedback -->
-      <div class="flex justify-between items-start mt-2">
-        <div class="flex flex-col">
-          <span class="text-sm" :class="{
-            'text-red-600': promptText.length > maxCharacters,
-            'text-gray-600': promptText.length <= maxCharacters
-          }">
-            {{ promptText.length }} / {{ maxCharacters }} characters
-          </span>
-          <div v-if="promptError" class="text-sm text-red-600 mt-1">
-            {{ promptError.message }}
+    <template v-else>
+      <div class="mb-8 p-6 bg-surface-container rounded-lg">
+        <h2 class="text-xl font-semibold mb-4">How AI Filtering Works</h2>
+        <p class="mb-4">
+          Seymour uses Claude AI to intelligently filter your RSS feeds based on your preferences.
+          You provide custom prompts that act as filtering criteria, and Claude decides which posts to show or hide.
+          This creates a personalized, curated timeline that matches your interests.
+        </p>
+        <p class="mb-4">
+          To curate your feed, simply describe what you'd like to see...or not see.
+          For example:
+        </p>
+        <div class="space-y-3">
+          <div class="bg-surface p-3 rounded border-l-4 border-primary">
+            <code class="text-sm">"Show me recipes for healthy meals, but not ones that include garlic."</code>
           </div>
         </div>
-
-        <button type="submit" :disabled="isSubmitting"
-          class="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
-          {{ isSubmitting ? 'Saving...' : 'Save Prompt' }}
-        </button>
+        <p class="mt-4 text-sm text-gray-600">
+          Your feed is in your control! As with any prompt, being incredibly descriptive or providing examples
+          will yield more favorable results.
+        </p>
       </div>
-    </form>
 
-    <!-- Success feedback (formerly SuccessView) -->
-    <div v-if="showSuccess" class="p-4 bg-green-100 text-green-800 rounded-lg flex items-center">
-      <svg class="w-5 h-5 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-        <path fill-rule="evenodd"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-          clip-rule="evenodd" />
-      </svg>
-      <span>Success! Your prompt has been saved and will filter future posts.</span>
-    </div>
+      <!-- Form section (formerly EditPromptView) -->
+      <form @submit.prevent="handleSubmit" class="mb-6">
+        <label for="prompt" class="block text-lg font-medium mb-3">
+          Your Filtering Prompt
+        </label>
+        <textarea id="prompt" v-model="promptText"
+          class="w-full h-64 px-4 py-3 border border-gray-300 rounded-lg resize-none focus:ring-2 focus:ring-primary focus:border-primary"
+          placeholder="Enter your filtering prompt here... For example: 'Show me posts about technology, programming, and AI, but hide posts about celebrity gossip or sports.'" />
 
-    <!-- Error feedback -->
-    <div v-if="submitErr" class="p-4 bg-red-100 text-red-800 rounded-lg flex items-center">
-      <svg class="w-5 h-5 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-        <path fill-rule="evenodd"
-          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
-          clip-rule="evenodd" />
-      </svg>
-      <span>{{ submitErr.message || 'Failed to save prompt. Please try again.' }}</span>
-    </div>
+        <!-- Character count and validation feedback -->
+        <div class="flex justify-between items-start mt-2">
+          <div class="flex flex-col">
+            <span class="text-sm" :class="{
+              'text-red-600': promptText.length > maxCharacters,
+              'text-gray-600': promptText.length <= maxCharacters
+            }">
+              {{ promptText.length }} / {{ maxCharacters }} characters
+            </span>
+            <div v-if="promptError" class="text-sm text-red-600 mt-1">
+              {{ promptError.message }}
+            </div>
+          </div>
+
+          <button type="submit" :disabled="isSubmitting"
+            class="px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+            {{ isSubmitting ? 'Saving...' : 'Save Prompt' }}
+          </button>
+        </div>
+      </form>
+
+      <!-- Success feedback (formerly SuccessView) -->
+      <div v-if="showSuccess" class="p-4 bg-green-100 text-green-800 rounded-lg flex items-center">
+        <svg class="w-5 h-5 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+            clip-rule="evenodd" />
+        </svg>
+        <span>Success! Your prompt has been saved and will filter future posts.</span>
+      </div>
+
+      <!-- Error feedback -->
+      <div v-if="submitErr" class="p-4 bg-red-100 text-red-800 rounded-lg flex items-center">
+        <svg class="w-5 h-5 mr-2 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd"
+            d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+            clip-rule="evenodd" />
+        </svg>
+        <span>{{ submitErr.message || 'Failed to save prompt. Please try again.' }}</span>
+      </div>
+    </template>
   </div>
 </template>
 
@@ -81,6 +85,7 @@
 import { ref } from 'vue'
 import { viewer } from '@/me'
 import useApiFetch from '@/use/useApiFetch'
+import EmptyPromptKey from '@/components/EmptyPromptKey.vue'
 
 const maxCharacters = 5000
 

--- a/src/views/SubscriptionsView.vue
+++ b/src/views/SubscriptionsView.vue
@@ -1,12 +1,13 @@
 <template>
-  <div class="flex flex-col gap-4">
+  <div class="flex flex-col gap-6 w-2xl">
     <div class="py-8">
       <h1 class="text-5xl font-bold">Your Subscriptions</h1>
     </div>
-    <RouterLink to="/subscriptions/new" class="w-fit mb-1">
+    <EmptySubscriptions v-if="data && data.subscriptions?.length === 0" />
+    <RouterLink v-else to="/subscriptions/new" class="w-fit mb-1">
       <StyledButton label="+ New Subscription" class="" />
     </RouterLink>
-    <SubscriptionItem v-for="subscription in data?.subscriptions" :key="subscription.id" :subscription="subscription" />
+    <SubscriptionItem v-else v-for="subscription in data?.subscriptions" :key="subscription.id" :subscription="subscription" />
   </div>
 </template>
 
@@ -17,6 +18,7 @@ import StyledButton from '@/components/StyledButton.vue';
 
 import useApiFetch from '@/use/useApiFetch';
 import SubscriptionItem from './internal/SubscriptionItem.vue';
+import EmptySubscriptions from '@/components/EmptySubscriptions.vue';
 
 const { call: fetchSubs, data } = useApiFetch("GET", `/api/subscriptions`)
 

--- a/src/views/TimelineView.vue
+++ b/src/views/TimelineView.vue
@@ -5,21 +5,26 @@
       <h2 class="text-xl py-4">{{ truncatedDescription }}</h2>
     </div>
 
-    <!-- Top pagination -->
-    <PaginationControls v-if="data?.pagination && data.pagination.total > data.pagination.limit"
-      :current-page="currentPage" :total-items="data.pagination.total" :items-per-page="data.pagination.limit"
-      @page-changed="handlePageChange" />
+    <EmptyFeed v-if="data && data.items?.length === 0 && route.query.feed_id" />
+    <EmptySubscriptions v-else-if="data && data.items?.length === 0" />
 
-    <RouterLink v-for="entry in data?.items" :key="entry.id" :to="`/article/${entry.entry_id}`"
-      class="w-full place-self-center mb-1">
-      <TimelineItem :entry="entry" />
-    </RouterLink>
+    <template v-else>
+      <!-- Top pagination -->
+      <PaginationControls v-if="data?.pagination && data.pagination.total > data.pagination.limit"
+        :current-page="currentPage" :total-items="data.pagination.total" :items-per-page="data.pagination.limit"
+        @page-changed="handlePageChange" />
 
-    <!-- Bottom pagination -->
-    <PaginationControls
-      v-if="data?.pagination && data.pagination.total > data.pagination.limit && (data?.items?.length >= 5)"
-      :current-page="currentPage" :total-items="data.pagination.total" :items-per-page="data.pagination.limit"
-      @page-changed="handlePageChange" />
+      <RouterLink v-for="entry in data?.items" :key="entry.id" :to="`/article/${entry.entry_id}`"
+        class="w-full place-self-center mb-1">
+        <TimelineItem :entry="entry" />
+      </RouterLink>
+
+      <!-- Bottom pagination -->
+      <PaginationControls
+        v-if="data?.pagination && data.pagination.total > data.pagination.limit && (data?.items?.length >= 5)"
+        :current-page="currentPage" :total-items="data.pagination.total" :items-per-page="data.pagination.limit"
+        @page-changed="handlePageChange" />
+    </template>
   </div>
 </template>
 
@@ -31,6 +36,8 @@ import { viewer } from '@/me';
 
 import TimelineItem from './internal/TimelineItem.vue';
 import PaginationControls from './internal/PaginationControls.vue';
+import EmptySubscriptions from '@/components/EmptySubscriptions.vue';
+import EmptyFeed from '@/components/EmptyFeed.vue';
 import { computed } from 'vue';
 
 const data = ref(null)


### PR DESCRIPTION
## Summary
- Replace `oh-vue-icons` with `@phosphor-icons/vue` for a cleaner icon library
- Add empty state components (`EmptyFeed`, `EmptySubscriptions`, `EmptyPromptKey`) so users see helpful guidance instead of blank pages
- Update `TimelineView`, `SubscriptionsView`, and `PromptView` to render the appropriate empty state when there's no data

## Test plan
- [ ] Verify the timeline shows the empty feed message when a feed has no posts
- [ ] Verify the timeline shows the empty subscriptions message when the user has no subscriptions
- [ ] Verify the subscriptions page shows the empty state with an "Add a Subscription" button when there are none
- [ ] Verify the prompt page shows the missing API key message when `has_prompt_key` is false
- [ ] Confirm Phosphor icons render correctly across all empty states

🤖 Generated with [Claude Code](https://claude.com/claude-code)